### PR TITLE
Header와 Footer 역할 새로 배정 #35

### DIFF
--- a/src/components/footer/footer.jsx
+++ b/src/components/footer/footer.jsx
@@ -1,5 +1,6 @@
 import 'react';
 import styled from 'styled-components';
+import useAuth from '../../hooks/auth/useAuth';
 
 const Container = styled.div`
   width: 100%;
@@ -7,10 +8,12 @@ const Container = styled.div`
   color: #dbdbdb;
   font-size: 15px;
   font-weight: 400;
+  cursor: pointer;
 `;
 
 function Footer() {
-  return <Container>제6대 컴퓨터공학부 학생회 LINK</Container>;
+  const { sendLoginUrl } = useAuth();
+  return <Container onClick={sendLoginUrl}>제6대 컴퓨터공학부 학생회 LINK</Container>;
 }
 
 export default Footer;

--- a/src/components/footer/footer.jsx
+++ b/src/components/footer/footer.jsx
@@ -8,7 +8,6 @@ const Container = styled.div`
   color: #dbdbdb;
   font-size: 15px;
   font-weight: 400;
-  cursor: pointer;
 `;
 
 function Footer() {

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -1,37 +1,24 @@
 import 'react';
 import styled from 'styled-components';
-import profileIcon from '../../assets/profileIcon.svg';
-import useAuth from '../../hooks/auth/useAuth.jsx';
 
 const HeaderContainer = styled.div`
   display: flex;
   width: 100%;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
 `;
 
 const HeaderTitle = styled.h1`
   color: #000;
   font-size: 40px;
-  font-style: normal;
   font-weight: 900;
-  line-height: normal;
   letter-spacing: -1.5px;
-  cursor: pointer;
-`;
-
-const HiddenIcon = styled.img`
-  visibility: hidden;
 `;
 
 const Header = () => {
-  const { sendLoginUrl } = useAuth();
-
   return (
     <HeaderContainer>
-      <HiddenIcon src={profileIcon} alt="헤더바 아이콘" />
-      <HeaderTitle onClick={sendLoginUrl}>LINKER</HeaderTitle>
-      <img src={profileIcon} alt="헤더바 아이콘" />
+      <HeaderTitle>LINKER</HeaderTitle>
     </HeaderContainer>
   );
 };

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -1,4 +1,5 @@
 import 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 const HeaderContainer = styled.div`
@@ -7,20 +8,22 @@ const HeaderContainer = styled.div`
   justify-content: center;
   align-items: center;
 `;
-
 const HeaderTitle = styled.h1`
   color: #000;
   font-size: 40px;
+  font-style: normal;
   font-weight: 900;
+  line-height: normal;
   letter-spacing: -1.5px;
+  cursor: pointer;
 `;
 
 const Header = () => {
+  const navigate = useNavigate();
   return (
     <HeaderContainer>
-      <HeaderTitle>LINKER</HeaderTitle>
+      <HeaderTitle onClick={() => navigate('/')}>LINKER</HeaderTitle>
     </HeaderContainer>
   );
 };
-
 export default Header;


### PR DESCRIPTION
## 📚 개요

- Header에 있는 유저 아이콘 삭제했습니다.
- sendLoginUrl API 연결 위치를 Header에서 Footer로 변경했습니다.
- Header 클릭 시 홈으로 가도록 구현했습니다.
- 
## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

